### PR TITLE
chore: prompt 输入和输出不一致

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -432,16 +432,16 @@ step by step
 > 输出
 
 ````
-总结：杰克和吉尔在探险中遭遇不幸，但最终平安归来，展现出了坚韧不拔的冒险精神。
-
-Traduction en français : Jack et Jill ont rencontré un malheur lors de leur aventure, mais sont finalement rentrés chez eux en toute sécurité, démontrant un esprit d'aventure résilient.
-
-Noms en français : Jack, Jill
-
-JSON 对象：
+1. 总结： 
+在一个迷人的村庄里，兄弟姐妹杰克和吉尔在探险途中遭遇了不幸，但最终安全返回家中，他们的探险精神未受影响。  
+2. 英语翻译：  
+In a charming village, siblings Jack and Jill faced misfortune on their adventure but returned home safely, their adventurous spirit undiminished.  
+3. 列出的名字：  
+Jack, Jill  
+4. JSON 对象输出：  
 ```json
 {
-  "french_summary": "Jack et Jill ont rencontré un malheur lors de leur aventure, mais sont finalement rentrés chez eux en toute sécurité, démontrant un esprit d'aventure résilient.",
+  "english_summary": "In a charming village, siblings Jack and Jill faced misfortune on their adventure but returned home safely, their adventurous spirit undiminished.",
   "num_names": 2
 }
 ```


### PR DESCRIPTION
````text
1 - 将下面由三个反引号分隔的文本进行总结，用一句话描述。

2 - 将总结翻译成英语。

3 - 在英语总结中列出每个名字。

4 - 输出一个包含以下键的 JSON 对象：english_summary、num_names。

文本：
```
在一个迷人的村庄里，兄弟姐妹杰克和吉尔踏上了从山顶井口取水的探险之旅。当他们欢快地唱着歌攀登时，不幸降临了——杰克在一块石头上绊倒，滚下了山坡，吉尔紧随其后。尽管稍微受了点伤，但他们俩还是安然无恙地回到了家中，得到了慰藉的拥抱。尽管遭遇了不幸，但他们的冒险精神仍然旺盛，他们继续欢快地探索着。
```
````

原文是需要的是英语，而输出是法语。